### PR TITLE
Don't actually say the word space

### DIFF
--- a/antipopd.m
+++ b/antipopd.m
@@ -61,7 +61,7 @@ void banner() {
 // Timer callback that actually speaks the space
 void speak(CFRunLoopTimerRef timer, void *info) {
 	if (onACPower) {
-		[(NSSpeechSynthesizer *)info startSpeakingString:@"space"];
+		[(NSSpeechSynthesizer *)info startSpeakingString:@" "];
 	}
 }
 


### PR DESCRIPTION
This fine utility still compiles after 4 years, but as it turns out it actually says the word "space", which is pretty funny ;)

Anyway, the fix is simple.